### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ or `\(` in LaTeX). The default style is Display. To switch to Text
 simply:
 
 ```swift
-label.labelMode = .label
+label.labelMode = .text
 ```
 
 ##### Text Alignment


### PR DESCRIPTION
I think there's a typo in the ##### Math mode section; original text read: "To switch to Text simply: label.labelMode = .label" and I think that last word is supposed to be "text" instead.